### PR TITLE
add compression to binaries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,4 +34,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          asset_paths: '["./bin/kubetrim*"]'
+          asset_paths: '["./uploads/*"]'

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SOURCE_DIRS = cmd pkg main.go
 export GO111MODULE=on
 
 .PHONY: all
-all: gofmt test build dist hash
+all: gofmt test build dist compress hash
 
 .PHONY: build
 build:
@@ -21,7 +21,10 @@ test:
 
 .PHONY: dist
 dist:
-	mkdir -p bin
+
+	mkdir -p bin/
+	mkdir -p uploads/
+	rm -rf bin/kubetrim*
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags $(LDFLAGS) -o bin/kubetrim
 	CGO_ENABLED=0 GOOS=darwin go build -ldflags $(LDFLAGS) -o bin/kubetrim-darwin
 	CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -a -ldflags $(LDFLAGS) -o bin/kubetrim-darwin-arm64
@@ -30,4 +33,8 @@ dist:
 
 .PHONY: hash
 hash:
-	rm -rf bin/*.sha256 && ./hack/hashgen.sh
+	rm -rf uploads/*.sha256 && ./hack/hashgen.sh
+
+.PHONY: compress
+compress:
+	./hack/compress.sh

--- a/hack/compress.sh
+++ b/hack/compress.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cd bin
+
+for f in kubetrim*; do tar -cvzf ../uploads/$f.tgz $f; done

--- a/hack/hashgen.sh
+++ b/hack/hashgen.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-for f in bin/kubetrim*; do shasum -a 256 $f > $f.sha256; done
+cd bin
+
+for f in kubetrim*; do shasum -a 256 $f > ../uploads/$f.sha256; done
+


### PR DESCRIPTION
Adds binary compression via changes to makefile and the addition of a new hack script to preform the compression

Tested in local repo Actions:

```
go build
mkdir -p bin/
mkdir -p uploads/
rm -rf bin/kubetrim*
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -X github.com/alexellis/kubetrim/pkg.Version= -X github.com/alexellis/kubetrim/pkg.GitCommit=0e65a100cd1c19f6[53](https://github.com/rgee0/kubetrim/actions/runs/10722512660/job/29733604009#step:4:54)dd120d3ee904acc2492cf0" -o bin/kubetrim
CGO_ENABLED=0 GOOS=darwin go build -ldflags "-s -w -X github.com/alexellis/kubetrim/pkg.Version= -X github.com/alexellis/kubetrim/pkg.GitCommit=0e65a100cd1c19f653dd120d3ee904acc2492cf0" -o bin/kubetrim-darwin
CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -a -ldflags "-s -w -X github.com/alexellis/kubetrim/pkg.Version= -X github.com/alexellis/kubetrim/pkg.GitCommit=0e65a100cd1c19f653dd120d3ee904acc2492cf0" -o bin/kubetrim-darwin-arm64
CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-s -w -X github.com/alexellis/kubetrim/pkg.Version= -X github.com/alexellis/kubetrim/pkg.GitCommit=0e65a100cd1c19f653dd120d3ee904acc2492cf0" -o bin/kubetrim-arm64
CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-s -w -X github.com/alexellis/kubetrim/pkg.Version= -X github.com/alexellis/kubetrim/pkg.GitCommit=0e65a100cd1c19f653dd120d3ee904acc2492cf0" -o bin/kubetrim.exe
./hack/compress.sh
kubetrim
kubetrim-arm64
kubetrim-darwin
kubetrim-darwin-arm64
kubetrim.exe
rm -rf uploads/*.sha256 && ./hack/hashgen.sh
```

Action exited green - https://github.com/rgee0/kubetrim/actions/runs/10722512660/job/29733604009 

Released binaries: https://github.com/rgee0/kubetrim/releases 

Closes #3 